### PR TITLE
fix prev/next post order

### DIFF
--- a/src/content/blog/08-prev-next-order-example/index.md
+++ b/src/content/blog/08-prev-next-order-example/index.md
@@ -1,0 +1,10 @@
+---
+title: "This post is to demonstrate proper Prev/Next navigation."
+description: "."
+date: "2024-03-18"
+draft: false
+---
+
+This post should show up in proper chronological order even though its folder comes last in the `content/blog` directory.
+
+The `Previous Post` and `Next Post` buttons under each blog post should also keep the proper chronological order, based on the frontmatter `date` field.

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -20,7 +20,9 @@ export async function getStaticPaths() {
 }
 type Props = CollectionEntry<"blog">;
 
-const posts = await getCollection("blog");
+const posts = (await getCollection("blog"))
+  .filter((post) => !post.data.draft)
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
 function getNextPost() {
   let postIndex;


### PR DESCRIPTION
Use a filtered and ordered list to pass into the `getNextPost` and `getPreviousPost` functions to preserve proper chronological order when navigating between posts.

Closes #26

I noticed that the main blog page would properly order posts by date, but when using the Previous and Next navigation buttons under each post it would revert to the folder order under `src/content/blog`. The `posts` variable used in these functions was not using an ordered list of blog posts.