### PR TITLE
hides empty Table of Contents

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -70,7 +70,7 @@ const { Content, headings } = await post.render();
         {post.data.title}
       </h1>
     </div>
-    <TableOfContents headings={headings} />
+    {headings.length > 0 && <TableOfContents headings={headings} />}
     <article class="animate">
       <Content />
       <div class="mt-24">


### PR DESCRIPTION
Problem: an empty Table of Contents is published at the top of posts without headings.

The code now checks for `headings` to have a length greater than 0 (meaning there is at least one heading). If `True` the ToC gets published at the top of the post. Otherwise, it's skipped.

If the markdown post does not have headings, an empty Table of Contents component will not be displayed anymore.