### PR TITLE
Fix issue #40: ignore Pagefind on root routes

### DIFF
--- a/src/components/PageFind.astro
+++ b/src/components/PageFind.astro
@@ -2,31 +2,33 @@
 import Search from "astro-pagefind/components/Search";
 ---
 
-<div
-  transition:persist
-  id="backdrop"
-  class="bg-[rgba(0, 0, 0, 0.5] invisible fixed left-0 top-0 z-50 flex h-screen w-full justify-center p-6 backdrop-blur-sm"
->
+<aside data-pagefind-ignore>
   <div
-    id="pagefind-container"
-    class="m-0 flex h-fit max-h-[80%] w-full max-w-screen-sm flex-col overflow-auto rounded border border-black/15 bg-neutral-100 p-2 px-4 py-3 shadow-lg dark:border-white/20 dark:bg-neutral-900"
+    transition:persist
+    id="backdrop"
+    class="bg-[rgba(0, 0, 0, 0.5] invisible fixed left-0 top-0 z-50 flex h-screen w-full justify-center p-6 backdrop-blur-sm"
   >
-    <Search
-      id="search"
-      className="pagefind-ui"
-      uiOptions={{
-        showImages: false,
-        excerptLength: 15,
-        resetStyles: false,
-      }}
-    />
-    <div class="mr-2 pb-1 pt-4 text-right text-xs dark:prose-invert">
-      Press <span class="prose text-xs dark:prose-invert"
-        ><kbd class="">Esc</kbd></span
-      > or click anywhere to close
+    <div
+      id="pagefind-container"
+      class="m-0 flex h-fit max-h-[80%] w-full max-w-screen-sm flex-col overflow-auto rounded border border-black/15 bg-neutral-100 p-2 px-4 py-3 shadow-lg dark:border-white/20 dark:bg-neutral-900"
+    >
+      <Search
+        id="search"
+        className="pagefind-ui"
+        uiOptions={{
+          showImages: false,
+          excerptLength: 15,
+          resetStyles: false,
+        }}
+      />
+      <div class="mr-2 pb-1 pt-4 text-right text-xs dark:prose-invert">
+        Press <span class="prose text-xs dark:prose-invert"
+          ><kbd class="">Esc</kbd></span
+        > or click anywhere to close
+      </div>
     </div>
   </div>
-</div>
+</aside>
 
 <script is:inline>
   const magnifyingGlass = document.getElementById("magnifying-glass");

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -27,25 +27,29 @@ const years = Object.keys(posts).sort((a, b) => parseInt(b) - parseInt(a));
 
 <Layout title={BLOG.TITLE} description={BLOG.DESCRIPTION}>
   <Container>
-    <div class="space-y-10">
-      <div class="space-y-4">
-        {
-          years.map((year) => (
-            <section class="animate space-y-4">
-              <div class="font-semibold text-black dark:text-white">{year}</div>
-              <div>
-                <ul class="not-prose flex flex-col gap-4">
-                  {posts[year].map((post) => (
-                    <li>
-                      <ArrowCard entry={post} />
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </section>
-          ))
-        }
+    <aside data-pagefind-ignore>
+      <div class="space-y-10">
+        <div class="space-y-4">
+          {
+            years.map((year) => (
+              <section class="animate space-y-4">
+                <div class="font-semibold text-black dark:text-white">
+                  {year}
+                </div>
+                <div>
+                  <ul class="not-prose flex flex-col gap-4">
+                    {posts[year].map((post) => (
+                      <li>
+                        <ArrowCard entry={post} />
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </section>
+            ))
+          }
+        </div>
       </div>
-    </div>
+    </aside>
   </Container>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,116 +22,124 @@ const projects: CollectionEntry<"projects">[] = (
 
 <Layout title={HOME.TITLE} description={HOME.DESCRIPTION}>
   <Container>
-    <h1 class="animate font-semibold text-black dark:text-white">
-      Introducing Astro Micro 🔬
-    </h1>
-    <div class="space-y-16">
-      <section>
-        <article class="space-y-4">
-          <span class="animate">
-            <p>
-              Astro Micro is an accessible theme for <Link
-                href="https://astro.build/">Astro</Link
-              >. It's a fork of
-              <Link href="https://github.com/markhorn-dev"> Mark Horn's </Link> popular
-              theme <Link href="https://astro.build/themes/details/astronano/"
-                >Astro Nano</Link
-              >. Like Nano, Micro comes with zero frameworks installed.
-            </p>
-            <p>
-              Micro adds features like <Link href="https://pagefind.app/"
-                >Pagefind</Link
-              > for search, <Link href="https://giscus.app">Giscus</Link> for comments,
-              and more. For a full list of changes, see this <Link
-                href="/blog/00-micro-changelog">blog post</Link
-              >.
-            </p>
-          </span>
-          <span class="animate">
-            <p>
-              Micro still comes with everything great about Nano — full type
-              safety, a sitemap, an RSS feed, and Markdown + MDX support. Styled
-              with TailwindCSS and preconfigured with system, light, and dark
-              themes.
-            </p>
-            <p>
-              Visit
-              <Link href="https://github.com/trevortylerlee/astro-micro">
-                Astro Micro on GitHub
-              </Link>
-              to fork the repository to get started.
-            </p>
-          </span>
-        </article>
-      </section>
-
-      <section class="animate space-y-6">
-        <div class="flex flex-wrap items-center justify-between gap-y-2">
-          <h2 class="font-semibold text-black dark:text-white">Latest posts</h2>
-          <Link href="/blog"> See all posts </Link>
-        </div>
-        <ul class="not-prose flex flex-col gap-4">
-          {
-            blog.map((post) => (
-              <li>
-                <ArrowCard entry={post} />
-              </li>
-            ))
-          }
-        </ul>
-      </section>
-
-      <section class="animate space-y-6">
-        <div class="flex flex-wrap items-center justify-between gap-y-2">
-          <h2 class="font-semibold text-black dark:text-white">
-            Recent projects
-          </h2>
-          <Link href="/projects"> See all projects </Link>
-        </div>
-        <ul class="not-prose flex flex-col gap-4">
-          {
-            projects.map((project) => (
-              <li>
-                <ArrowCard entry={project} />
-              </li>
-            ))
-          }
-        </ul>
-      </section>
-
-      <section class="animate space-y-4">
-        <h2 class="font-semibold text-black dark:text-white">Let's Connect</h2>
-        <article>
-          <p>
-            If you want to get in touch with me about something or just to say
-            hi, reach out on social media or send me an email.
-          </p>
-        </article>
-        <ul class="not-prose flex flex-wrap gap-2">
-          {
-            SOCIALS.map((SOCIAL) => (
-              <li class="flex gap-x-2 text-nowrap">
-                <Link
-                  href={SOCIAL.HREF}
-                  external
-                  aria-label={`${SITE.TITLE} on ${SOCIAL.NAME}`}
-                >
-                  {SOCIAL.NAME}
+    <aside data-pagefind-ignore>
+      <h1 class="animate font-semibold text-black dark:text-white">
+        Introducing Astro Micro 🔬
+      </h1>
+      <div class="space-y-16">
+        <section>
+          <article class="space-y-4">
+            <span class="animate">
+              <p>
+                Astro Micro is an accessible theme for <Link
+                  href="https://astro.build/">Astro</Link
+                >. It's a fork of
+                <Link href="https://github.com/markhorn-dev">
+                  Mark Horn's
+                </Link> popular theme <Link
+                  href="https://astro.build/themes/details/astronano/"
+                  >Astro Nano</Link
+                >. Like Nano, Micro comes with zero frameworks installed.
+              </p>
+              <p>
+                Micro adds features like <Link href="https://pagefind.app/"
+                  >Pagefind</Link
+                > for search, <Link href="https://giscus.app">Giscus</Link> for comments,
+                and more. For a full list of changes, see this <Link
+                  href="/blog/00-micro-changelog">blog post</Link
+                >.
+              </p>
+            </span>
+            <span class="animate">
+              <p>
+                Micro still comes with everything great about Nano — full type
+                safety, a sitemap, an RSS feed, and Markdown + MDX support.
+                Styled with TailwindCSS and preconfigured with system, light,
+                and dark themes.
+              </p>
+              <p>
+                Visit
+                <Link href="https://github.com/trevortylerlee/astro-micro">
+                  Astro Micro on GitHub
                 </Link>
-                {"/"}
-              </li>
-            ))
-          }
-          <li class="line-clamp-1">
-            <Link
-              href={`mailto:${SITE.EMAIL}`}
-              aria-label={`Email ${SITE.TITLE}`}
-            >
-              {SITE.EMAIL}
-            </Link>
-          </li>
-        </ul>
-      </section>
-    </div>
+                to fork the repository to get started.
+              </p>
+            </span>
+          </article>
+        </section>
+
+        <section class="animate space-y-6">
+          <div class="flex flex-wrap items-center justify-between gap-y-2">
+            <h2 class="font-semibold text-black dark:text-white">
+              Latest posts
+            </h2>
+            <Link href="/blog"> See all posts </Link>
+          </div>
+          <ul class="not-prose flex flex-col gap-4">
+            {
+              blog.map((post) => (
+                <li>
+                  <ArrowCard entry={post} />
+                </li>
+              ))
+            }
+          </ul>
+        </section>
+
+        <section class="animate space-y-6">
+          <div class="flex flex-wrap items-center justify-between gap-y-2">
+            <h2 class="font-semibold text-black dark:text-white">
+              Recent projects
+            </h2>
+            <Link href="/projects"> See all projects </Link>
+          </div>
+          <ul class="not-prose flex flex-col gap-4">
+            {
+              projects.map((project) => (
+                <li>
+                  <ArrowCard entry={project} />
+                </li>
+              ))
+            }
+          </ul>
+        </section>
+
+        <section class="animate space-y-4">
+          <h2 class="font-semibold text-black dark:text-white">
+            Let's Connect
+          </h2>
+          <article>
+            <p>
+              If you want to get in touch with me about something or just to say
+              hi, reach out on social media or send me an email.
+            </p>
+          </article>
+          <ul class="not-prose flex flex-wrap gap-2">
+            {
+              SOCIALS.map((SOCIAL) => (
+                <li class="flex gap-x-2 text-nowrap">
+                  <Link
+                    href={SOCIAL.HREF}
+                    external
+                    aria-label={`${SITE.TITLE} on ${SOCIAL.NAME}`}
+                  >
+                    {SOCIAL.NAME}
+                  </Link>
+                  {"/"}
+                </li>
+              ))
+            }
+            <li class="line-clamp-1">
+              <Link
+                href={`mailto:${SITE.EMAIL}`}
+                aria-label={`Email ${SITE.TITLE}`}
+              >
+                {SITE.EMAIL}
+              </Link>
+            </li>
+          </ul>
+        </section>
+      </div>
+    </aside>
   </Container>
 </Layout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -12,19 +12,21 @@ const projects = (await getCollection("projects"))
 
 <Layout title={PROJECTS.TITLE} description={PROJECTS.DESCRIPTION}>
   <Container>
-    <div class="space-y-10">
-      <div class="animate font-semibold text-black dark:text-white">
-        Projects
+    <aside data-pagefind-ignore>
+      <div class="space-y-10">
+        <div class="animate font-semibold text-black dark:text-white">
+          Projects
+        </div>
+        <ul class="animate not-prose flex flex-col gap-4">
+          {
+            projects.map((project) => (
+              <li>
+                <ArrowCard entry={project} />
+              </li>
+            ))
+          }
+        </ul>
       </div>
-      <ul class="animate not-prose flex flex-col gap-4">
-        {
-          projects.map((project) => (
-            <li>
-              <ArrowCard entry={project} />
-            </li>
-          ))
-        }
-      </ul>
-    </div>
+    </aside>
   </Container>
 </Layout>


### PR DESCRIPTION
### Issues

Closes #40 , Pagefind indexing `root`, `blog/`, `projects/`, and `itself` causing double-index.

### Changes

Solved by [Removing individual elements from the index](https://pagefind.app/docs/indexing/#removing-individual-elements-from-the-index), basically adding `<aside data-pagefind-ignore>` on four root pages/components mentioned above.

There are actually two ways excluding index from Pagefind, however
1. Running the `Pagefind CLI` AGAIN is not considerable on maintaining the project by a PR
2. It's more clear to point out which component to ignore by a HTML tag(using aside) for users considering cases if they want to add another route aside from blog or projects.

### Serve checks

Since there's no test checks on this project, I have validated by both on vercel deployment and a local serve. Here is a basic example changing after this PR pagefind no longer indexing itself.

<img width="748" alt="스크린샷 2024-07-19 오전 1 34 59" src="https://github.com/user-attachments/assets/08384e6f-0120-4060-83b2-e5ad15480e28">
