### PR TITLE
Fix issue #43: close Pagefind when result clicked

### DIFF
--- a/src/components/PageFind.astro
+++ b/src/components/PageFind.astro
@@ -73,6 +73,13 @@ import Search from "astro-pagefind/components/Search";
     }
   });
 
+  // close pagefind when searched result(link) clicked
+  document.addEventListener("click", (event) => {
+    if (event.target.classList.contains("pagefind-ui__result-link")) {
+      closePagefind();
+    }
+  });
+
   backdrop?.addEventListener("click", (event) => {
     if (!event.target.closest("#pagefind-container")) {
       closePagefind();


### PR DESCRIPTION
### Issues
Closes #43 , Pagefind not being closed even when result is clicked.

### Changes
Added an EventListener which observes one of the search result is clicked, by classname `pagefind-ui__result-link` using predefined function `closePagefind`.
I don't see any side effects on this PR since there's no other clickable areas to route rather than the title of results.

### Serve Checks
Done checking by a vercel deployment and a local serve as before.

<br />
PS thanks for this amazing blog template tho