### PR TITLE
feat: fix some warnings on build

### DIFF
--- a/src/components/Callout.astro
+++ b/src/components/Callout.astro
@@ -1,5 +1,5 @@
 ---
-interface Component {
+interface Props {
   type: "default" | "info" | "warning" | "error";
 }
 

--- a/src/components/PageFind.astro
+++ b/src/components/PageFind.astro
@@ -68,7 +68,7 @@ import Search from "astro-pagefind/components/Search";
 
   // close pagefind
   document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape" || e.keyCode === 27) {
+    if (e.key === "Escape") {
       closePagefind();
     }
   });

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,7 +1,6 @@
 ---
 import Layout from "@layouts/Layout.astro";
 import Container from "@components/Container.astro";
-import Link from "@components/Link.astro";
 import BackToPrevious from "@components/BackToPrevious.astro";
 import { SITE } from "@consts";
 ---


### PR DESCRIPTION
* Callout.astro had it's props interface named "Component" instead of "Props"
* PageFind had a check with the keyCode numerical value which is deprecated
* 404 page had a reference to Link which is not used