### PR TITLE
fix: Table of Contents Links Not Redirecting Correctly

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -7,7 +7,7 @@ const toc = buildToc(headings);
 
 export interface Heading {
   depth: number;
-  id: string;
+  slug: string;
   text: string;
 }
 

--- a/src/components/TableOfContentsHeading.astro
+++ b/src/components/TableOfContentsHeading.astro
@@ -8,7 +8,7 @@ const { heading } = Astro.props;
 ---
 
 <li class="list-inside list-disc px-6 py-1.5 text-sm">
-  <Link href={"#" + heading.id} underline>
+  <Link href={"#" + heading.slug} underline>
     {heading.text}
   </Link>
   {


### PR DESCRIPTION
### Fix: Table of Contents Links Not Redirecting Correctly

#### Description
This PR fixes an issue where the Table of Contents (TOC) links in blog posts and the projects page were not redirecting to the correct sections. Clicking on a TOC item previously updated the URL with `#undefined` but failed to navigate to the intended section.

#### Changes Made
Renamed `id` to `slug` in `Heading` interface. 
According to [astro docs](https://docs.astro.build/en/guides/markdown-content/#importing-markdown): 
>Each heading’s slug corresponds to the generated ID for a given heading and can be used for anchor links 


#### Steps to Verify
1. Go to a blog post or the projects page.
2. Use the TOC to navigate by clicking on any item.
3. Confirm that:
   - The URL updates with the correct anchor link (e.g., `#section-title`).
   - The page scrolls to the corresponding section.

#### Related Issue
Fixes Issue #75

#### Videos
https://github.com/user-attachments/assets/16145357-b72f-4b59-b25e-351a4e484fee
