### PR TITLE
fix invisible content when javascript is disabled

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,6 +19,14 @@ const { title, description } = Astro.props;
     <Head title={`${title} | ${SITE.TITLE}`} description={description} />
   </head>
   <body>
+    <noscript>
+      <style>
+        .animate{
+          opacity:1;
+          translate: var(--tw-translate-x) calc(var(--spacing) * 0);
+        }
+      </style>
+    </noscript>
     <Header />
     <main>
       <slot />


### PR DESCRIPTION
Fixes #101

The noscript tag works great as a fallback, only difference is all elements are revealed at the same time.